### PR TITLE
Github workflow to build and publish a release.

### DIFF
--- a/.github/workflows/flawfinder.yml
+++ b/.github/workflows/flawfinder.yml
@@ -1,0 +1,39 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: flawfinder
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '35 6 * * 4'
+
+jobs:
+  flawfinder:
+    name: Flawfinder
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: flawfinder_scan
+        uses: david-a-wheeler/flawfinder@8e4a779ad59dbfaee5da586aa9210853b701959c
+        with:
+          arguments: '--sarif ./'
+          output: 'flawfinder_results.sarif'
+
+      - name: Upload analysis results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{github.workspace}}/flawfinder_results.sarif

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,61 @@
+name: Ubicloud SPDK release
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    env:
+      INSTALL_PREFIX: ${{ github.workspace }}/install/spdk
+      TARBALL_PATH: ${{ github.workspace }}/ubicloud-spdk-ubuntu-22.04-x64.tar.gz
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+      - name: Checkout SPDK and submodules
+        uses: actions/checkout@v4
+        with:
+          repository: spdk/spdk
+          ref: refs/tags/v23.09
+          fetch-depth: 0
+          submodules: 'recursive'
+          path: 'spdk'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install liburing-dev
+          sudo spdk/scripts/pkgdep.sh
+      - name: Configure
+        run: spdk/configure --with-crypto --with-vhost --target-arch=corei7 --prefix=$INSTALL_PREFIX --pydir=$INSTALL_PREFIX/python/lib --disable-unit-tests --disable-tests --disable-examples
+      - name: Build SPDK
+        run: cd spdk && make -j16
+      - name: Install
+        run: |
+          cd spdk
+          make install
+          cp -R python/* $INSTALL_PREFIX/python/
+          mkdir $INSTALL_PREFIX/scripts
+          cp scripts/rpc.py $INSTALL_PREFIX/scripts
+      - name: Build bdev_ubi
+        run: |
+          SPDK_PATH=$INSTALL_PREFIX make
+          cp build/bin/vhost_ubi $INSTALL_PREFIX/bin/
+      - name: Package
+        run: |
+          cd $INSTALL_PREFIX/..
+          tar --create --gzip --file=$TARBALL_PATH spdk
+      - uses: ncipollo/release-action@v1
+        if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'
+        with:
+          artifacts: "${{ env.TARBALL_PATH }}"
+          body: "Release ${{ github.ref_name }}"
+          allowUpdates: true


### PR DESCRIPTION
This workflow will just build the project without creating a release when a commit is pushed to master or a pull request is created.

It also publishes a release if manually triggered by a maintainer of the project on a tag reference.

The tarball that's created contains an SPDK installation + the vhost_ubi binary from the bdev_ubi project.

Github's actions/create-release@v1 [1] isn't maintained anymore and fails with an error if used, so we used ncipollo/release-action to publish releases.

This is based on Cloud-hypervisor's EDK2 fork's release.yaml [3], except that we fix couple of things that doesn't work anymore:

1. Don't use actions/create-release@v1 action
2. `github.event.ref_type` => `github.ref_type`

[1] https://github.com/actions/create-release
[2] https://github.com/ncipollo/release-action
[3]
https://raw.githubusercontent.com/cloud-hypervisor/edk2/92c79b2901c24de6a0859b8ad4f0b1a2bfa79503/.github/workflows/release.yaml