### PR TITLE
Check C code style automatically on CI.

### DIFF
--- a/.github/scripts/check-format.sh
+++ b/.github/scripts/check-format.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+make format
+git diff --quiet
+
+if [ $? -ne 0 ]; then
+    echo "Error: Code style check failed."
+    git diff
+    exit 1
+fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
+      - name: Check formatting
+        run: .github/scripts/check-format.sh
       - name: Checkout SPDK and submodules
         uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ APP_DIR := app
 OBJ_DIR := build/obj
 BIN_DIR := build/bin
 
+ifneq ($(MAKECMDGOALS),format)
 PKG_CONFIG_PATH = $(SPDK_PATH)/lib/pkgconfig
 SPDK_DPDK_LIB := $(shell PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config --libs spdk_event spdk_event_vhost_blk spdk_event_bdev spdk_event_scheduler spdk_env_dpdk)
 SYS_LIB := $(shell PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config --libs --static spdk_syslibs)
@@ -16,6 +17,7 @@ SPDK_DPDK_LIB += -lrte_net
 # Compiler and linker flags
 CFLAGS := -D_GNU_SOURCE -Iinclude -Wall -g -O3 -I$(SPDK_PATH)/include
 LDFLAGS := -Wl,--whole-archive,-Bstatic $(SPDK_DPDK_LIB) -Wl,--no-whole-archive -luring -Wl,-Bdynamic $(SYS_LIB)
+endif
 
 # Automatically generate a list of source files (.c) and object files (.o)
 SRCS := $(wildcard $(SRC_DIR)/*.c)

--- a/src/bdev_ubi_io_channel.c
+++ b/src/bdev_ubi_io_channel.c
@@ -15,7 +15,8 @@ static void get_buf_for_read_cb(struct spdk_io_channel *ch, struct spdk_bdev_io 
                                 bool success);
 static int ubi_submit_read_request(struct ubi_bdev_io *ubi_io);
 static int ubi_submit_write_request(struct ubi_bdev_io *ubi_io);
-static void ubi_io_completion_cb(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg);
+static void ubi_io_completion_cb(struct spdk_bdev_io *bdev_io, bool success,
+                                 void *cb_arg);
 static void ubi_complete_io(struct ubi_bdev_io *ubi_io, bool success);
 static void ubi_init_ext_io_opts(struct spdk_bdev_io *bdev_io,
                                  struct spdk_bdev_ext_io_opts *opts);
@@ -364,23 +365,22 @@ static int ubi_submit_write_request(struct ubi_bdev_io *ubi_io) {
 /*
  * ubi_io_completion_cb cleans up and marks the I/O request as completed.
  */
-static void ubi_io_completion_cb(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg) {
+static void ubi_io_completion_cb(struct spdk_bdev_io *bdev_io, bool success,
+                                 void *cb_arg) {
     spdk_bdev_free_io(bdev_io);
 
     struct ubi_bdev_io *ubi_io = cb_arg;
     ubi_complete_io(ubi_io, success);
 }
 
-static void ubi_complete_io(struct ubi_bdev_io *ubi_io, bool success)
-{
-    struct spdk_bdev_io * bdev_io = spdk_bdev_io_from_ctx(ubi_io);
+static void ubi_complete_io(struct ubi_bdev_io *ubi_io, bool success) {
+    struct spdk_bdev_io *bdev_io = spdk_bdev_io_from_ctx(ubi_io);
 
     if (bdev_io->type == SPDK_BDEV_IO_TYPE_READ)
         ubi_io->ubi_ch->active_reads--;
 
-    spdk_bdev_io_complete(bdev_io,
-                          success ? SPDK_BDEV_IO_STATUS_SUCCESS
-                                  : SPDK_BDEV_IO_STATUS_FAILED);
+    spdk_bdev_io_complete(bdev_io, success ? SPDK_BDEV_IO_STATUS_SUCCESS
+                                           : SPDK_BDEV_IO_STATUS_FAILED);
 }
 
 /*

--- a/src/bdev_ubi_rpc.c
+++ b/src/bdev_ubi_rpc.c
@@ -33,8 +33,8 @@ static const struct spdk_json_object_decoder rpc_construct_ubi_decoders[] = {
     {"no_sync", offsetof(struct rpc_construct_ubi, no_sync), spdk_json_decode_bool, true},
     {"copy_on_read", offsetof(struct rpc_construct_ubi, copy_on_read),
      spdk_json_decode_bool, true},
-    {"directio", offsetof(struct rpc_construct_ubi, directio),
-     spdk_json_decode_bool, true}};
+    {"directio", offsetof(struct rpc_construct_ubi, directio), spdk_json_decode_bool,
+     true}};
 
 static void bdev_ubi_create_done(void *cb_arg, struct spdk_bdev *bdev, int status) {
     struct spdk_jsonrpc_request *request = cb_arg;


### PR DESCRIPTION
We often forget to run `make format` when checking in code. Add a check in the github workflow to check the style automatically and error out if it doesn't comply.