### PR TITLE
Add test coverage data & increase coverage.

### DIFF
--- a/.github/scripts/check-coverage.sh
+++ b/.github/scripts/check-coverage.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+make coverage
+
+target=70.0
+p=$(lcov --summary coverage.info | grep "lines" | grep -Eo "[0-9]+\.[0-9]+")
+if (( $(echo "$p < $target" | bc -l) )); then
+    echo "Error: Coverage $p% is less than $target%"
+    exit 1 
+fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt install liburing-dev
+          sudo apt install liburing-dev lcov
           sudo spdk/scripts/pkgdep.sh
       - name: Configure
         run: spdk/configure --with-crypto --with-vhost --target-arch=corei7 --prefix=$INSTALL_PREFIX --pydir=$INSTALL_PREFIX/python/lib --disable-unit-tests --disable-tests --disable-examples
@@ -47,14 +47,20 @@ jobs:
           cp -R python/* $INSTALL_PREFIX/python/
           mkdir $INSTALL_PREFIX/scripts
           cp scripts/rpc.py $INSTALL_PREFIX/scripts
-      - name: Build bdev_ubi
-        run: |
-          SPDK_PATH=$INSTALL_PREFIX make
-          cp build/bin/vhost_ubi $INSTALL_PREFIX/bin/
-      - name: Run tests
+      - name: Run tests and check coverage
         run: |
           sudo spdk/scripts/setup.sh
-          SPDK_PATH=$INSTALL_PREFIX make check
+          export SPDK_PATH=$INSTALL_PREFIX
+          make clean
+          make COVERAGE=true
+          make check
+          .github/scripts/check-coverage.sh
+      - name: Build bdev_ubi
+        run: |
+          export SPDK_PATH=$INSTALL_PREFIX
+          make clean
+          make
+          cp build/bin/vhost_ubi $INSTALL_PREFIX/bin/
       - name: Package
         run: |
           cd $INSTALL_PREFIX/..

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/*
 .vscode/*
 valgrind.log
+coverage.info
+coverage_report/*

--- a/test/test_conf.json
+++ b/test/test_conf.json
@@ -19,7 +19,68 @@
             "image_path": "build/bin/test_image.raw",
             "stripe_size_kb": 1024,
             "copy_on_read": false,
-            "directio": true
+            "directio": false,
+            "no_sync": false
+          }
+        },
+        {
+          "method": "bdev_malloc_create",
+          "params": {
+            "name": "malloc1",
+            "block_size": 512,
+            "num_blocks": 204800
+          }
+        },
+        {
+          "method": "bdev_ubi_create",
+          "params": {
+            "name": "ubi_copy_on_read",
+            "base_bdev": "malloc1",
+            "image_path": "build/bin/test_image.raw",
+            "stripe_size_kb": 1024,
+            "copy_on_read": true,
+            "directio": false,
+            "no_sync": false
+          }
+        },
+        {
+          "method": "bdev_malloc_create",
+          "params": {
+            "name": "malloc2",
+            "block_size": 512,
+            "num_blocks": 204800
+          }
+        },
+        {
+          "method": "bdev_ubi_create",
+          "params": {
+            "name": "ubi_directio",
+            "base_bdev": "malloc2",
+            "image_path": "build/bin/test_image.raw",
+            "stripe_size_kb": 1024,
+            "copy_on_read": false,
+            "directio": true,
+            "no_sync": false
+          }
+        },
+        {
+          "method": "bdev_malloc_create",
+          "params": {
+            "name": "malloc3",
+            "block_size": 512,
+            "num_blocks": 204800
+          }
+        },
+        {
+          "method": "bdev_ubi_create",
+          "params": {
+            "name": "ubi_nosync",
+            "base_bdev": "malloc3",
+            "image_path": "build/bin/test_image.raw",
+            "stripe_size_kb": 1024,
+            "copy_on_read": false,
+            "directio": false,
+            "no_sync": true
           }
         },
         {


### PR DESCRIPTION
Adds test coverage data and generates coverage report using `lcov`. To generate and see a coverage report do:

```
export SPDK_PATH=/path/to/spdk
make COVERAGE=true
make check
make coverage_report
ruby -run -e httpd ./coverage_report/ -p 8000
```

Furthermore, made some changes to `memcheck_ubi` and `test_ubi` test programs to test more combinations so we have higher coverage.

Also, added coverage check to the github flow to detect regressions in test coverage.
