### PR TITLE
Add Ubuntu 24.04 & use SPDK v23.09 in build pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,14 +15,20 @@ jobs:
       matrix:
         include:
           - runner: ubicloud-standard-4
-            platform: x64
+            platform: ubuntu-22.04-x64
+            target_arch: corei7
+          - runner:  ubicloud-standard-4-ubuntu-2404
+            platform: ubuntu-24.04-x64
             target_arch: corei7
           - runner: ubicloud-standard-4-arm
-            platform: arm64
+            platform: ubuntu-22.04-arm64
+            target_arch: native
+          - runner: ubicloud-standard-4-arm-ubuntu-2404
+            platform: ubuntu-24.04-arm64
             target_arch: native
     env:
       INSTALL_PREFIX: ${{ github.workspace }}/install/spdk
-      TARBALL_PATH: ${{ github.workspace }}/ubicloud-spdk-ubuntu-22.04-${{ matrix.platform }}.tar.gz
+      TARBALL_PATH: ${{ github.workspace }}/ubicloud-spdk-${{ matrix.platform }}.tar.gz
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: spdk/spdk
-          ref: refs/tags/v24.01
+          ref: refs/tags/v23.09
           fetch-depth: 0
           submodules: 'recursive'
           path: 'spdk'
@@ -53,14 +53,13 @@ jobs:
           sudo apt install liburing-dev lcov
           sudo spdk/scripts/pkgdep.sh
       - name: Configure
-        run: spdk/configure --with-crypto --with-vhost --without-nvme-cuse --target-arch=${{ matrix.target_arch }} --prefix=$INSTALL_PREFIX --disable-unit-tests --disable-tests --disable-examples
+        run: spdk/configure --with-crypto --with-vhost --without-nvme-cuse --target-arch=${{ matrix.target_arch }} --prefix=$INSTALL_PREFIX --pydir=$INSTALL_PREFIX/python/lib --disable-unit-tests --disable-tests --disable-examples
       - name: Build SPDK
         run: cd spdk && make -j16
       - name: Install
         run: |
           cd spdk
           make install
-          mkdir -p $INSTALL_PREFIX/python
           cp -R python/* $INSTALL_PREFIX/python/
           mkdir $INSTALL_PREFIX/scripts
           cp scripts/rpc.py $INSTALL_PREFIX/scripts


### PR DESCRIPTION
* Add Ubuntu 24.04 builds to the release pipeline.
* Use SPDK v23.09 instead of SPDK v24.01 in the build pipeline.

Previously I had merged the change to use v24.01 because it passed bdev_ubi regression tests and some local manual tests.

But when I tried it along with Ubicloud recently, it failed with:

```
spdk_rpc.rb:113:in `call': Input/output error (SpdkRpcError)
```

So, we change the SPDK version for releases back to SPDK v23.09 to unblock releasing binaries for Ubuntu 24.04. The issues with newer versions of SPDK will be fixed in a separate PR.

Note that we never tried SPDK v24.01 in production, so this isn't a downgrade of what we are already running.
